### PR TITLE
Do not write sentinels on a second init

### DIFF
--- a/core/php7.1Action/router.php
+++ b/core/php7.1Action/router.php
@@ -93,7 +93,9 @@ function init() : array
 {
     // check that we haven't already been initialised
     if (file_exists(ACTION_CONFIG_FILE)) {
-        throw new RuntimeException('Cannot initialize the action more than once.', 403);
+        writeTo("php://stdout", 'Error: Cannot initialize the action more than once.');
+        http_response_code(403);
+        return ['error' => 'Cannot initialize the action more than once.'];
     }
 
     // data is POSTed to us as a JSON string

--- a/core/php7.2Action/router.php
+++ b/core/php7.2Action/router.php
@@ -124,7 +124,9 @@ function init() : array
 {
     // check that we haven't already been initialised
     if (file_exists(ACTION_CONFIG_FILE)) {
-        throw new RuntimeException('Cannot initialize the action more than once.', 403);
+        writeTo("php://stdout", 'Error: Cannot initialize the action more than once.');
+        http_response_code(403);
+        return ['error' => 'Cannot initialize the action more than once.'];
     }
 
     // data is POSTed to us as a JSON string


### PR DESCRIPTION
If a second /init is attempted, we don't want to write sentinels as this
will truncate the log stream.

Requires https://github.com/apache/incubator-openwhisk/pull/3840 to be merged first.