### PR TITLE
PHP 7.3 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@
 
 ## PHP versions
 
-This runtime provides PHP 7.2 and 7.1.
+This runtime provides PHP 7.3, 7.2 and 7.1.
 
 ### Give it a try today
 To use as a docker action
+
+PHP 7.3:
+```
+wsk action update myAction myAction.php --docker openwhisk/action-php-v7.3:latest
+```
 
 PHP 7.2:
 ```
@@ -41,8 +46,13 @@ wsk action update myAction myAction.php --docker openwhisk/action-php-v7.1:lates
 
 This works on any deployment of Apache OpenWhisk
 
-### To use on deployment that contains the rutime as a kind
+### To use on deployment that contains the runtime as a kind
 To use as a kind action
+
+PHP 7.3:
+```
+wsk action update myAction myAction.php --kind php:7.3
+```
 
 PHP 7.2:
 ```
@@ -56,19 +66,21 @@ wsk action update myAction myAction.php --kind php:7.1
 
 ### Local development
 ```
+./gradlew core:php7.3Action:distDocker
 ./gradlew core:php7.2Action:distDocker
 ./gradlew core:php7.1Action:distDocker
 ```
-This will produce the images `whisk/action-php-v7.2` & `whisk/action-php-v7.1`
+This will produce the images `whisk/action-php-v7.3`, `whisk/action-php-v7.2` & `whisk/action-php-v7.1`
 
 Build and Push image
 ```
 docker login
+./gradlew core:php7.3Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ./gradlew core:php7.2Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ./gradlew core:php7.1Action:distDocker -PdockerImagePrefix=$prefix-user -PdockerRegistry=docker.io
 ```
 
-Deploy OpenWhisk using ansible environment that contains the kinds `php:7.2` & `php:7.1`
+Deploy OpenWhisk using ansible environment that contains the kinds `php:7.3`, `php:7.2` & `php:7.1`
 Assuming you have OpenWhisk already deploy locally and `OPENWHISK_HOME` pointing to root directory of OpenWhisk core repository.
 
 Set `ROOTDIR` to the root directory of this repository.
@@ -92,6 +104,10 @@ wskdev fresh -t local-php
 
 To use as docker action push to your own dockerhub account
 ```
+docker tag whisk/php7.2Action $user_prefix/action-php-v7.3
+docker push $user_prefix/action-php-v7.3
+```
+```
 docker tag whisk/php7.2Action $user_prefix/action-php-v7.2
 docker push $user_prefix/action-php-v7.2
 ```
@@ -101,7 +117,7 @@ docker push $user_prefix/action-php-v7.1
 ```
 Then create the action using your the image from dockerhub
 ```
-wsk action update myAction myAction.php --docker $user_prefix/action-php-v7.2
+wsk action update myAction myAction.php --docker $user_prefix/action-php-v7.3
 ```
 The `$user_prefix` is usually your dockerhub user id.
 

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -1,0 +1,38 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## 1.0.0
+Initial release
+
+- Added: PHP: 7.3.0
+- Added: PHP extensions in addition to the standard ones:
+    - bcmath
+    - curl
+    - gd
+    - intl
+    - mbstring
+    - mysqli
+    - pdo_mysql
+    - pdo_pgsql
+    - pdo_sqlite
+    - soap
+    - zip
+- Added: Composer packages:
+    - [guzzlehttp/guzzle](https://packagist.org/packages/guzzlehttp/guzzle): 6.3.3
+    - [ramsey/uuid](https://packagist.org/packages/ramsey/uuid): 3.8.0

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -17,7 +17,7 @@
 
 FROM openwhisk/actionloop:410d006 as builder
 
-FROM php:7.3.0RC6-cli-stretch
+FROM php:7.3.0-cli-stretch
 
 # install dependencies
 RUN \

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openwhisk/actionloop:4535d61 as builder
+FROM openwhisk/actionloop:410d006 as builder
 
 FROM php:7.3.0RC6-cli-stretch
 

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM openwhisk/actionloop:4535d61 as builder
+
+FROM php:7.3.0RC6-cli-stretch
+
+# install dependencies
+RUN \
+    apt-get -y update && \
+    apt-get -y install \
+      libfreetype6-dev \
+      libicu-dev \
+      libicu57 \
+      libjpeg-dev \
+      libpng-dev \
+      libxml2-dev \
+      libzip-dev \
+      postgresql-server-dev-9.6 \
+      unzip \
+      zlib1g-dev
+
+# Install useful PHP extensions
+RUN \
+    docker-php-ext-install \
+      bcmath \
+      gd \
+      intl \
+      mysqli \
+      opcache \
+      pdo_mysql \
+      pdo_pgsql \
+      soap \
+      zip
+
+COPY php.ini /usr/local/etc/php
+
+# install composer
+RUN curl -s -f -L -o /tmp/installer.php https://getcomposer.org/installer \
+    && php /tmp/installer.php --no-ansi --install-dir=/usr/bin --filename=composer \
+    && composer --ansi --version --no-interaction --no-plugins --no-scripts
+
+
+# install default Composer dependencies
+RUN mkdir -p /phpAction/composer
+COPY composer.json /phpAction/composer
+RUN cd /phpAction/composer && /usr/bin/composer install --no-plugins --no-scripts --prefer-dist --no-dev -o && rm composer.lock
+
+# install proxy binary alogn with compile and launcher scripts
+RUN mkdir -p /phpAction/action
+WORKDIR /phpAction
+COPY --from=builder /bin/proxy /bin/proxy
+ADD compile /bin/compile
+ADD runner.php /bin/runner.php
+ENV OW_COMPILER=/bin/compile
+
+ENTRYPOINT [ "/bin/proxy" ]

--- a/core/php7.3Action/build.gradle
+++ b/core/php7.3Action/build.gradle
@@ -15,24 +15,5 @@
  * limitations under the License.
  */
 
-include 'tests'
-
-include 'core:php7.1Action'
-include 'core:php7.2Action'
-include 'core:php7.3Action'
-
-rootProject.name = 'runtime-php'
-
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+ext.dockerImageName = 'action-php-v7.3'
+apply from: '../../gradle/docker.gradle'

--- a/core/php7.3Action/compile
+++ b/core/php7.3Action/compile
@@ -1,0 +1,82 @@
+#!/usr/bin/env php
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * compile
+ *
+ * This file is launched by the action proxy.
+ * It copies runner.php to right source directory and creates a bash exec script
+ * that the action proxy will call to start everything off
+ */
+
+main($argc, $argv);
+exit;
+
+function main($argc, $argv)
+{
+    if ($argc < 4) {
+        print("usage: <main-function-name> <source-dir> <bin-dir>");
+        exit(1);
+    }
+    $main = $argv[1];
+    $src = realpath($argv[2]);
+    $bin = realpath($argv[3]);
+
+    $shim = $bin.'/exec';
+
+    sources($src);
+    build($shim, $src, $main);
+}
+
+/**
+ * Sort out the source code
+ *
+ * 1. Copy src/exec to src/index.php if necessary
+ * 2. Ensure vendor directory exists
+ */
+function sources(string $src)
+{
+    // If the file uploaded by the user is a plain PHP file, then
+    // the filename will be called exec by the action proxy.
+    // Rename it to index.php
+    if (file_exists($src . '/exec')) {
+        rename($src . '/exec', $src . '/index.php');
+    }
+
+    // put vendor in the right place if it doesn't exist
+    if (!is_dir($src . '/vendor')) {
+        exec('cp -a /phpAction/composer/vendor ' . escapeshellarg($src . '/vendor'));
+    }
+}
+
+/**
+ * Create bin/exec shim
+ */
+function build(string $shim, string $src, string $main) : void
+{
+    $contents = <<<EOT
+#!/bin/bash
+cd $src
+exec php -f /bin/runner.php -- "$main"
+
+EOT;
+
+    file_put_contents($shim, $contents);
+    chmod($shim, 0755);
+}

--- a/core/php7.3Action/composer.json
+++ b/core/php7.3Action/composer.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+        "platform": {
+            "php": "7.3"
+        }
+    },
+    "require": {
+        "guzzlehttp/guzzle": "6.3.3",
+        "ramsey/uuid": "3.8.0"
+    }
+}

--- a/core/php7.3Action/php.ini
+++ b/core/php7.3Action/php.ini
@@ -1,0 +1,37 @@
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.
+; The ASF licenses this file to You under the Apache License, Version 2.0
+; (the "License"); you may not use this file except in compliance with
+; the License.  You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+[PHP]
+short_open_tag = Off
+output_buffering = Off
+expose_php = Off
+max_execution_time = 0
+memory_limit = -1
+error_reporting = E_ALL
+display_errors = Off
+log_errors = On
+log_errors_max_len = 0
+html_errors = Off
+variables_order = "EGPCS"
+request_order = "GP"
+post_max_size = 0
+enable_dl = Off
+zend.assertions = -1
+
+[opcache]
+opcache.enable=1
+opcache.enable_cli=1
+opcache.max_accelerated_files=7963
+opcache.validate_timestamps=0

--- a/core/php7.3Action/runner.php
+++ b/core/php7.3Action/runner.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * PHP Action runner
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// open fd/3 as that's where we send the result
+$fd3 = fopen('php://fd/3', 'w');
+
+// Register a shutdown function so that we can fail gracefully when a fatal error occurs
+register_shutdown_function(function () use ($fd3) {
+    $error = error_get_last();
+    if ($error && in_array($error['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR])) {
+        file_put_contents('php://stderr', "An error occurred running the action.\n");
+        fwrite($fd3, "An error occurred running the action.\n");
+    }
+    fclose($fd3);
+});
+
+require 'vendor/autoload.php';
+require 'index.php';
+
+// retrieve main function
+$__functionName = $argv[1] ?? 'main';
+
+
+// read stdin
+while ($f = fgets(STDIN)) {
+    // call the function
+    $data = json_decode($f ?? '', true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+
+    // convert all parameters other than value to environment variables
+    foreach ($data as $key => $value) {
+        if ($key == 'value') {
+            $_ENV['WHISK_INPUT'] = $data['value'] ?? [];
+        } else {
+            $_ENV['__OW_' . strtoupper($key)] = $value;
+        }
+    }
+
+    $values = $data['value'] ?? [];
+    try {
+        $result = $__functionName($values);
+
+        // convert result to an array if we can
+        if (is_object($result)) {
+            if (method_exists($result, 'getArrayCopy')) {
+                $result = $result->getArrayCopy();
+            } elseif ($result instanceof stdClass) {
+                $result = (array)$result;
+            }
+        } elseif ($result === null) {
+            $result = [];
+        }
+
+        // process the result
+        if (!is_array($result)) {
+            file_put_contents('php://stderr', 'Result must be an array but has type "'
+                . gettype($result) . '": ' . (string)$result);
+            file_put_contents('php://stdout', 'The action did not return a dictionary.');
+            $result = (string)$result;
+        } else {
+            $result = json_encode((object)$result);
+        }
+    } catch (Throwable $e) {
+        file_put_contents('php://stderr', (string)$e);
+        $result = 'An error occurred running the action.';
+    }
+
+    // ensure that the sentinels will be on their own lines
+    file_put_contents('php://stderr', "\n");
+    file_put_contents('php://stdout', "\n");
+
+    // cast result to an object for json_encode to ensure that an empty array becomes "{}" & send to fd/3
+    fwrite($fd3, $result . "\n");
+}

--- a/tests/src/test/scala/runtime/actionContainers/Php71ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php71ActionContainerTests.scala
@@ -19,6 +19,8 @@ package runtime.actionContainers
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
+import actionContainers.ResourceHelpers.ZipBuilder
+import spray.json._
 
 @RunWith(classOf[JUnitRunner])
 class Php71ActionContainerTests extends Php7ActionContainerTests {
@@ -27,4 +29,89 @@ class Php71ActionContainerTests extends Php7ActionContainerTests {
 
   override val testLargeInput = TestConfig("", skipTest = true)
 
+  it should "fail to initialize with bad code" in {
+    val (out, err) = withPhp7Container { c =>
+      val code = """
+                |<?php
+                | 10 PRINT "Hello world!"
+                | 20 GOTO 10
+            """.stripMargin
+
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("PHP syntax error")
+    }
+
+    // Somewhere, the logs should mention an error occurred.
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("syntax")
+    })
+  }
+
+  it should "fail gracefully on invalid zip files" in {
+    // Some text-file encoded to base64.
+    val code = "Q2VjaSBuJ2VzdCBwYXMgdW4gemlwLgo="
+
+    val (out, err) = withPhp7Container { c =>
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("Failed to open zip file")
+    }
+
+    // Somewhere, the logs should mention the failure
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("failed to open zip file")
+    })
+  }
+
+  it should "fail gracefully on valid zip files that are not actions" in {
+    val srcs = Seq(Seq("hello") -> """
+                | Hello world!
+            """.stripMargin)
+
+    val code = ZipBuilder.mkBase64Zip(srcs)
+
+    val (out, err) = withPhp7Container { c =>
+      c.init(initPayload(code))._1 should not be (200)
+    }
+
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("zipped actions must contain index.php at the root.")
+    })
+  }
+
+  it should "fail gracefully on valid zip files with invalid code in index.php" in {
+    val (out, err) = withPhp7Container { c =>
+      val srcs = Seq(Seq("index.php") -> """
+                    | <?php
+                    | 10 PRINT "Hello world!"
+                    | 20 GOTO 10
+                """.stripMargin)
+
+      val code = ZipBuilder.mkBase64Zip(srcs)
+
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("PHP syntax error in index.php")
+    }
+
+    // Somewhere, the logs should mention an error occurred.
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("syntax")
+    })
+  }
 }

--- a/tests/src/test/scala/runtime/actionContainers/Php72ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php72ActionContainerTests.scala
@@ -19,9 +19,97 @@ package runtime.actionContainers
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
+import actionContainers.ResourceHelpers.ZipBuilder
+import spray.json._
 
 @RunWith(classOf[JUnitRunner])
 class Php72ActionContainerTests extends Php7ActionContainerTests {
 
   override lazy val phpContainerImageName = "action-php-v7.2"
+
+  it should "fail to initialize with bad code" in {
+    val (out, err) = withPhp7Container { c =>
+      val code = """
+                |<?php
+                | 10 PRINT "Hello world!"
+                | 20 GOTO 10
+            """.stripMargin
+
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("PHP syntax error")
+    }
+
+    // Somewhere, the logs should mention an error occurred.
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("syntax")
+    })
+  }
+
+  it should "fail gracefully on invalid zip files" in {
+    // Some text-file encoded to base64.
+    val code = "Q2VjaSBuJ2VzdCBwYXMgdW4gemlwLgo="
+
+    val (out, err) = withPhp7Container { c =>
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("Failed to open zip file")
+    }
+
+    // Somewhere, the logs should mention the failure
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("failed to open zip file")
+    })
+  }
+
+  it should "fail gracefully on valid zip files that are not actions" in {
+    val srcs = Seq(Seq("hello") -> """
+                | Hello world!
+            """.stripMargin)
+
+    val code = ZipBuilder.mkBase64Zip(srcs)
+
+    val (out, err) = withPhp7Container { c =>
+      c.init(initPayload(code))._1 should not be (200)
+    }
+
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("zipped actions must contain index.php at the root.")
+    })
+  }
+
+  it should "fail gracefully on valid zip files with invalid code in index.php" in {
+    val (out, err) = withPhp7Container { c =>
+      val srcs = Seq(Seq("index.php") -> """
+                    | <?php
+                    | 10 PRINT "Hello world!"
+                    | 20 GOTO 10
+                """.stripMargin)
+
+      val code = ZipBuilder.mkBase64Zip(srcs)
+
+      val (initCode, error) = c.init(initPayload(code))
+      initCode should not be (200)
+      error shouldBe a[Some[_]]
+      error.get shouldBe a[JsObject]
+      error.get.fields("error").toString should include("PHP syntax error in index.php")
+    }
+
+    // Somewhere, the logs should mention an error occurred.
+    checkStreams(out, err, {
+      case (o, e) =>
+        (o + e).toLowerCase should include("error")
+        (o + e).toLowerCase should include("syntax")
+    })
+  }
 }

--- a/tests/src/test/scala/runtime/actionContainers/Php73ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php73ActionContainerTests.scala
@@ -15,24 +15,13 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'core:php7.1Action'
-include 'core:php7.2Action'
-include 'core:php7.3Action'
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-rootProject.name = 'runtime-php'
+@RunWith(classOf[JUnitRunner])
+class Php73ActionContainerTests extends Php7ActionContainerTests {
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
-
-gradle.ext.scala = [
-    version: '2.12.7',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+  override lazy val phpContainerImageName = "action-php-v7.3"
+}

--- a/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Php7ActionContainerTests.scala
@@ -129,29 +129,6 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
       """.stripMargin)
   }
 
-  it should "fail to initialize with bad code" in {
-    val (out, err) = withPhp7Container { c =>
-      val code = """
-                |<?php
-                | 10 PRINT "Hello world!"
-                | 20 GOTO 10
-            """.stripMargin
-
-      val (initCode, error) = c.init(initPayload(code))
-      initCode should not be (200)
-      error shouldBe a[Some[_]]
-      error.get shouldBe a[JsObject]
-      error.get.fields("error").toString should include("PHP syntax error")
-    }
-
-    // Somewhere, the logs should mention an error occurred.
-    checkStreams(out, err, {
-      case (o, e) =>
-        (o + e).toLowerCase should include("error")
-        (o + e).toLowerCase should include("syntax")
-    })
-  }
-
   it should "return some error on action error" in {
     val (out, err) = withPhp7Container { c =>
       val code = """
@@ -219,7 +196,6 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
 
       runRes shouldBe defined
       runRes.get.fields.get("error") shouldBe defined
-      runRes.get.fields("error").toString should include("An error occurred running the action.")
     }
 
     // Somewhere, the logs should be the error text
@@ -414,69 +390,6 @@ abstract class Php7ActionContainerTests extends BasicActionRunnerTests with WskA
       runRes.get.fields.get("result") shouldBe defined
       runRes.get.fields.get("result") shouldBe Some(JsString("stranger"))
     }
-  }
-
-  it should "fail gracefully on invalid zip files" in {
-    // Some text-file encoded to base64.
-    val code = "Q2VjaSBuJ2VzdCBwYXMgdW4gemlwLgo="
-
-    val (out, err) = withPhp7Container { c =>
-      val (initCode, error) = c.init(initPayload(code))
-      initCode should not be (200)
-      error shouldBe a[Some[_]]
-      error.get shouldBe a[JsObject]
-      error.get.fields("error").toString should include("Failed to open zip file")
-    }
-
-    // Somewhere, the logs should mention the failure
-    checkStreams(out, err, {
-      case (o, e) =>
-        (o + e).toLowerCase should include("error")
-        (o + e).toLowerCase should include("failed to open zip file")
-    })
-  }
-
-  it should "fail gracefully on valid zip files that are not actions" in {
-    val srcs = Seq(Seq("hello") -> """
-                | Hello world!
-            """.stripMargin)
-
-    val code = ZipBuilder.mkBase64Zip(srcs)
-
-    val (out, err) = withPhp7Container { c =>
-      c.init(initPayload(code))._1 should not be (200)
-    }
-
-    checkStreams(out, err, {
-      case (o, e) =>
-        (o + e).toLowerCase should include("error")
-        (o + e).toLowerCase should include("zipped actions must contain index.php at the root.")
-    })
-  }
-
-  it should "fail gracefully on valid zip files with invalid code in index.php" in {
-    val (out, err) = withPhp7Container { c =>
-      val srcs = Seq(Seq("index.php") -> """
-                    | <?php
-                    | 10 PRINT "Hello world!"
-                    | 20 GOTO 10
-                """.stripMargin)
-
-      val code = ZipBuilder.mkBase64Zip(srcs)
-
-      val (initCode, error) = c.init(initPayload(code))
-      initCode should not be (200)
-      error shouldBe a[Some[_]]
-      error.get shouldBe a[JsObject]
-      error.get.fields("error").toString should include("PHP syntax error in index.php")
-    }
-
-    // Somewhere, the logs should mention an error occurred.
-    checkStreams(out, err, {
-      case (o, e) =>
-        (o + e).toLowerCase should include("error")
-        (o + e).toLowerCase should include("syntax")
-    })
   }
 
   it should "support zipped actions using non-default entry point" in {

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -38,6 +38,10 @@ TERM=dumb ./gradlew install
 echo "openwhisk.home=$WHISKDIR" > whisk.properties
 echo "vcap.services.file=" >> whisk.properties
 
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+docker version
+
 # Build runtime
 cd $ROOTDIR
 TERM=dumb ./gradlew distDocker


### PR DESCRIPTION
PHP7.3 support for when it releases in early December.

This runtime uses the Go runtime's ActionProxy as the front end. This speeds things up nicely!

However, it also means that the detailed error reporting for invalid
data being uploaded to /init is not possible as this is handled by the
proxy. As a result, the specific tests that this affects have been
moved to the PHP 7.1 and 7.2 test classes.

Also, it's not possible to send back specific error messages for output
with the action proxy, so the fatal error test no longer checks for the
specific error text.