### PR TITLE
Update to php7.1.27, 7.2.16 and 7.3.3.

### DIFF
--- a/core/php7.1Action/CHANGELOG.md
+++ b/core/php7.1Action/CHANGELOG.md
@@ -19,8 +19,9 @@
 
 ## Apache 1.13.0-incubating (next release)
 Changes:
-  - Update version of PHP to 7.1.26
+  - Update version of PHP to 7.1.27
 
+## 1.12.0-incubating
 ## 1.0.3
 Changes:
   - Allow /run endpoint to accept more environment variables [#40](https://github.com/apache/incubator-openwhisk-runtime-php/pull/40)

--- a/core/php7.1Action/Dockerfile
+++ b/core/php7.1Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.1.26-alpine
+FROM php:7.1.27-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.2Action/CHANGELOG.md
+++ b/core/php7.2Action/CHANGELOG.md
@@ -19,8 +19,9 @@
 
 ## Apache 1.13.0-incubating (next release)
 Changes:
-  - Update version of PHP to 7.2.15
+  - Update version of PHP to 7.2.16
 
+## 1.12.0-incubating
 ## 1.0.2
 Changes:
   - Allow /run endpoint to accept more environment variables [#40](https://github.com/apache/incubator-openwhisk-runtime-php/pull/40)

--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.15-alpine
+FROM php:7.2.16-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## Apache 1.13.0-incubating (next release)
 Initial release
 
-- Added: PHP: 7.3.2
+- Added: PHP: 7.3.3
 - Added: PHP extensions in addition to the standard ones:
     - bcmath
     - curl

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-FROM openwhisk/actionloop:410d006 as builder
+FROM openwhisk/actionloop:42fd5e6 as builder
 
-FROM php:7.3.2-cli-stretch
+FROM php:7.3.3-cli-stretch
 
 # install dependencies
 RUN \


### PR DESCRIPTION
- Update openwhisk/action-php-v7.3 runtime to php 7.3.3 (security fixes, see https://www.php.net/).
- Update openwhisk/action-php-v7.3 to actionloop 42fd5e6 (see https://github.com/apache/incubator-openwhisk-runtime-go).
- Update openwhisk/action-php-v7.2 runtime to php 7.2.16 (security fixes, see https://www.php.net/).
- Update openwhisk/action-php-v7.1 runtime to php 7.1.27 (security fixes, see https://www.php.net/)..