### PR TITLE
Adapt to current actionloop release tag.

### DIFF
--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -16,10 +16,10 @@
 #
 
 FROM golang:1.11 as builder
-ENV PROXY_SOURCE=https://github.com/apache/incubator-openwhisk-runtime-go/archive/1.11@1.13.0-incubating.tar.gz
+ENV PROXY_SOURCE=https://github.com/apache/incubator-openwhisk-runtime-go/archive/golang1.11@1.13.0-incubating.tar.gz
 RUN curl -L "$PROXY_SOURCE" | tar xzf - \
   && mkdir -p src/github.com/apache \
-  && mv incubator-openwhisk-runtime-go-1.11-1.13.0-incubating \
+  && mv incubator-openwhisk-runtime-go-golang1.11-1.13.0-incubating \
      src/github.com/apache/incubator-openwhisk-runtime-go \
   && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
   && CGO_ENABLED=0 go build -o /bin/proxy


### PR DESCRIPTION
The release tag of the actionloop (https://github.com/apache/incubator-openwhisk-runtime-go) is set to 'golang1.11@1.13.0-incubating'. The code was looking for '1.11@v1.13.0-incubating'. This causes the travis build to fail.
Adjusted the Dockerfile to use the new value to unblock the travis build.