### PR TITLE
Bump php runtimes to version 7.1.29, 7.2.19 and 7.3.5.

### DIFF
--- a/core/php7.1Action/CHANGELOG.md
+++ b/core/php7.1Action/CHANGELOG.md
@@ -17,7 +17,11 @@
 #
 -->
 
-## Apache 1.13.0-incubating (next release)
+## Apache 1.14.0-incubating (next release)
+Changes:
+  - Update version of PHP to 7.1.29
+
+## Apache 1.13.0-incubating
 Changes:
   - Update version of PHP to 7.1.27
 

--- a/core/php7.1Action/Dockerfile
+++ b/core/php7.1Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.1.27-alpine
+FROM php:7.1.29-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.2Action/CHANGELOG.md
+++ b/core/php7.2Action/CHANGELOG.md
@@ -17,7 +17,11 @@
 #
 -->
 
-## Apache 1.13.0-incubating (next release)
+## Apache 1.14.0-incubating (next release)
+Changes:
+  - Update version of PHP to 7.2.18
+
+## Apache 1.13.0-incubating
 Changes:
   - Update version of PHP to 7.2.16
 

--- a/core/php7.2Action/Dockerfile
+++ b/core/php7.2Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM php:7.2.16-alpine
+FROM php:7.2.18-alpine
 
 RUN \
     apk update && apk upgrade && \

--- a/core/php7.3Action/CHANGELOG.md
+++ b/core/php7.3Action/CHANGELOG.md
@@ -16,8 +16,11 @@
 # limitations under the License.
 #
 -->
+## Apache 1.14.0-incubating (next release)
+Changes:
+  - Update version of PHP to 7.3.5
 
-## Apache 1.13.0-incubating (next release)
+## Apache 1.13.0-incubating
 Initial release
 
 - Added: PHP: 7.3.3

--- a/core/php7.3Action/Dockerfile
+++ b/core/php7.3Action/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -L "$PROXY_SOURCE" | tar xzf - \
      src/github.com/apache/incubator-openwhisk-runtime-go \
   && cd src/github.com/apache/incubator-openwhisk-runtime-go/main \
   && CGO_ENABLED=0 go build -o /bin/proxy
-FROM php:7.3.3-cli-stretch
+FROM php:7.3.5-cli-stretch
 
 # install dependencies
 RUN \


### PR DESCRIPTION
  * The new versions contain bug fixes and security fixes.

I hope I updated the CHANGELOG.md files correctly. Feel free to leave a message if it should look different :-).